### PR TITLE
Fix nested post route definition

### DIFF
--- a/server/logs/combined.log
+++ b/server/logs/combined.log
@@ -277,3 +277,14 @@
 [32minfo[39m: Received payload from Mirth Connect {"contentType":"application/json","service":"lab-results-api","timestamp":"2025-07-30T21:28:28.185Z"}
 [32minfo[39m: LDT parsing debug: {"originalPayload":"[object Object]","parsedRecords":[],"parsedRecordsCount":0,"service":"lab-results-api","timestamp":"2025-07-30T21:28:28.185Z"}
 [32minfo[39m: POST /api/mirth-webhook - 422 - 4ms - User: anonymous {"service":"lab-results-api","timestamp":"2025-07-30T21:28:28.188Z"}
+[32minfo[39m: Server running on http://localhost:5000 {"service":"lab-results-api","timestamp":"2025-08-04T22:56:11.677Z"}
+[32minfo[39m: Environment: development {"service":"lab-results-api","timestamp":"2025-08-04T22:56:11.679Z"}
+[32minfo[39m: User management system initialized with default users: {"service":"lab-results-api","timestamp":"2025-08-04T22:56:11.679Z"}
+[32minfo[39m:   Admin: admin@laborresults.de / admin123 {"service":"lab-results-api","timestamp":"2025-08-04T22:56:11.679Z"}
+[32minfo[39m:   Doctor: doctor@laborresults.de / doctor123 {"service":"lab-results-api","timestamp":"2025-08-04T22:56:11.679Z"}
+[32minfo[39m:   Lab Tech: lab@laborresults.de / lab123 {"service":"lab-results-api","timestamp":"2025-08-04T22:56:11.679Z"}
+[32minfo[39m: Received payload from Mirth Connect {"contentType":"text/plain","service":"lab-results-api","size":7,"timestamp":"2025-08-04T22:56:16.356Z"}
+[32minfo[39m: LDT parsing debug: {"originalPayload":"Test123","parsedRecords":[],"parsedRecordsCount":0,"service":"lab-results-api","timestamp":"2025-08-04T22:56:16.357Z"}
+[32minfo[39m: POST /api/mirth-webhook - 422 - 3ms - 122bytes - User: anonymous {"service":"lab-results-api","timestamp":"2025-08-04T22:56:16.357Z"}
+[32minfo[39m: Received payload from Mirth Connect (alternative route) {"contentType":"text/plain","service":"lab-results-api","size":14,"timestamp":"2025-08-04T22:56:18.138Z"}
+[32minfo[39m: POST /api/mirth/webhook - 422 - 1ms - 61bytes - User: anonymous {"service":"lab-results-api","timestamp":"2025-08-04T22:56:18.139Z"}

--- a/server/server.js
+++ b/server/server.js
@@ -1070,6 +1070,9 @@ app.post(
       contentType: req.headers['content-type'],
       size: req.body ? req.body.length : 0,
     });
+    
+    // Debug: Log the actual content for troubleshooting
+    logger.info('Raw payload content:', req.body.toString());
 
     // Handle different content types
     let ldtPayload;
@@ -1178,6 +1181,9 @@ app.post(
       contentType: req.headers['content-type'],
       size: req.body ? req.body.length : 0,
     });
+    
+    // Debug: Log the actual content for troubleshooting
+    logger.info('Raw payload content (alternative route):', req.body.toString());
 
     // Handle different content types
     let ldtPayload;


### PR DESCRIPTION
Add logging of raw payload content to Mirth Connect webhook routes to improve debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-7167a8bc-1226-48d1-82c3-57384102c3e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7167a8bc-1226-48d1-82c3-57384102c3e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>