### PR TITLE
Fix three critical code bugs

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -55,11 +55,16 @@ class UserModel {
     this.usersByBsnrLanr = new Map();
 
     // Initialize with default admin user
-    this.initializeDefaultUsers();
+    if (process.env.NODE_ENV !== 'production') {
+      this.initializeDefaultUsers();
+    }
   }
 
   // Initialize default users for testing
   async initializeDefaultUsers() {
+    if (process.env.NODE_ENV === 'production') {
+      return; // Safety: never create default users in production
+    }
     try {
       // Create default admin user
       const adminUser = await this.createUser({


### PR DESCRIPTION
### Summary

- This PR addresses three bugs:
    1.  **Hardened Webhook Signature Verification:** Previously, an empty `MIRTH_WEBHOOK_SECRET` could bypass HMAC verification, and `crypto.timingSafeEqual` could throw on length mismatches. The fix requires a non-empty secret and adds a length check before `timingSafeEqual` to prevent errors and ensure secure comparison.
    2.  **Asynchronous Webhook Raw Logging:** The `fs.writeFileSync` call in the webhook path was blocking the event loop, causing performance degradation under load. This has been converted to use `fs.promises.writeFile` with `await` for non-blocking I/O.
    3.  **Prevented Default User Creation in Production:** Hard-coded default users were being created unconditionally, posing a security risk in production environments. Default user initialization is now strictly gated to non-production environments.

### Checklists

- [x] Security: no secrets committed; updated `SECURITY.md` if policy changed
- [ ] Tenancy: isolation preserved; RLS unaffected; updated `TENANCY.md` if needed
- [ ] Migrations: backward compatible; runbook updated; tested locally
- [ ] Tests: unit/integration/e2e updated; CI green
- [ ] Docs: README and relevant canonical docs updated
- [ ] Ops: runbooks unaffected or updated (`OPERATION.md`)

### Risk/Impact

- **Webhook Verification:** Increased security; potential for webhooks to fail if `MIRTH_WEBHOOK_SECRET` is not properly configured (empty or missing) in environments where it was previously implicitly accepted.
- **Async Logging:** Improved performance under load; no functional change.
- **Default Users:** Enhanced security; no impact on production as default users should not be created there.

### Screenshots/Logs (if applicable)
N/A

---
<a href="https://cursor.com/background-agent?bcId=bc-af198e43-cee7-489f-9d22-790048116c0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af198e43-cee7-489f-9d22-790048116c0d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

